### PR TITLE
Configure SWD interface and target device speed so user isn't prompted

### DIFF
--- a/nrftool/script/erase.jlink
+++ b/nrftool/script/erase.jlink
@@ -1,3 +1,5 @@
+si 1
+speed 1000
 device nrf51822
 w4 4001e504 2
 w4 4001e50c 1

--- a/nrftool/script/flash_nrf52.jlink
+++ b/nrftool/script/flash_nrf52.jlink
@@ -1,5 +1,6 @@
-device nrf52
+si 1
 speed 1000
+device nrf52
 w4 4001e504 1
 loadbin {firmware} {address}
 sleep 100


### PR DESCRIPTION
I noticed that the JLink programmer was prompting for user input under the hood - adding these configurations to the scripts lets it continue without interruption.
